### PR TITLE
feat(Omnibar): add `rootStyle`

### DIFF
--- a/src/Omnibar.tsx
+++ b/src/Omnibar.tsx
@@ -15,8 +15,11 @@ export default class Omnibar<T> extends React.PureComponent<
         extensions: [],
         maxViewableResults: null,
         rowHeight: 50,
-        resultStyle: {},
         inputDelay: 100,
+
+        // style props
+        resultStyle: {},
+        rootStyle: { position: 'relative' },
     };
 
     state: Omnibar.State<T> = {
@@ -74,9 +77,10 @@ export default class Omnibar<T> extends React.PureComponent<
         // uses the hovered index if the user is currently
         // mousing over an item, falls back on the
         // selected index
-        const idx = this.state.hoveredIndex > -1
-            ? this.state.hoveredIndex
-            : this.state.selectedIndex;
+        const idx =
+            this.state.hoveredIndex > -1
+                ? this.state.hoveredIndex
+                : this.state.selectedIndex;
         const item = this.state.results[idx];
         const action = this.props.onAction || AnchorAction;
         action.call(null, item);
@@ -140,12 +144,14 @@ export default class Omnibar<T> extends React.PureComponent<
             defaultValue,
             width,
             height,
-            inputStyle,
             rowHeight,
-            rowStyle,
-            resultStyle,
             resultRenderer,
             onAction,
+            // style props
+            inputStyle,
+            rootStyle,
+            rowStyle,
+            resultStyle,
         } = this.props;
 
         const maxHeight = maxViewableResults
@@ -153,7 +159,7 @@ export default class Omnibar<T> extends React.PureComponent<
             : null;
 
         return (
-            <div style={{ position: 'relative' }}>
+            <div style={rootStyle}>
                 {React.createElement(Input, {
                     defaultValue,
                     width,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,13 +22,15 @@ declare namespace Omnibar {
         // optional input bar height
         height?: number;
         // optional input bar style override
-        inputStyle?: React.CSSProperties
+        inputStyle?: React.CSSProperties;
         // optional result item height
         rowHeight?: number;
         // optional result item style override
         rowStyle?: React.CSSProperties;
         // optional result list style override
         resultStyle?: React.CSSProperties;
+        // options style on the root element
+        rootStyle?: React.CSSProperties;
         // optional result renderering function
         resultRenderer?: <T>(item: T) => React.ReactChild;
         // optional action override


### PR DESCRIPTION
closes the original concern of https://github.com/vutran/omnibar/issues/1

- adds `rootStyle` on the root element of the component
    - allows full override (no style composition). `position: relative` is the default rule on a `div` anyway

![screen shot 2017-10-31 at 17 12 05](https://user-images.githubusercontent.com/462507/32235051-b37d5bd6-be5e-11e7-85f4-725d9409c3ea.png)
