### PR TITLE
refactor(Omnibar): clean up `query` method

### DIFF
--- a/src/Omnibar.tsx
+++ b/src/Omnibar.tsx
@@ -32,15 +32,14 @@ export default class Omnibar<T> extends React.PureComponent<
     }
 
     query = (value: string) => {
-        if (this.props.extensions.length) {
-            search<T>(value, this.props.extensions).then(items => {
-                if (items.length) {
-                    let results = items;
-                    if (this.props.maxResults) {
-                        results = results.slice(0, this.props.maxResults);
-                    }
-                    this.setState({ results, displayResults: true });
-                }
+        if (this.props.extensions.length > 0) {
+            search<T>(value, this.props.extensions).then(results => {
+                this.setState({
+                    results: this.props.maxResults
+                        ? results.slice(0, this.props.maxResults)
+                        : results,
+                    displayResults: results.length > 0,
+                });
             });
         }
     };
@@ -74,9 +73,10 @@ export default class Omnibar<T> extends React.PureComponent<
         // uses the hovered index if the user is currently
         // mousing over an item, falls back on the
         // selected index
-        const idx = this.state.hoveredIndex > -1
-            ? this.state.hoveredIndex
-            : this.state.selectedIndex;
+        const idx =
+            this.state.hoveredIndex > -1
+                ? this.state.hoveredIndex
+                : this.state.selectedIndex;
         const item = this.state.results[idx];
         const action = this.props.onAction || AnchorAction;
         action.call(null, item);

--- a/src/Omnibar.tsx
+++ b/src/Omnibar.tsx
@@ -35,9 +35,10 @@ export default class Omnibar<T> extends React.PureComponent<
         if (this.props.extensions.length > 0) {
             search<T>(value, this.props.extensions).then(results => {
                 this.setState({
-                    results: this.props.maxResults
-                        ? results.slice(0, this.props.maxResults)
-                        : results,
+                    results:
+                        this.props.maxResults > 0
+                            ? results.slice(0, this.props.maxResults)
+                            : results,
                     displayResults: results.length > 0,
                 });
             });


### PR DESCRIPTION

- cleans up `query` method
- removing hard coding of `displayResults`
     - instead we set `displayResults` if `results.length > 0`

tbh, it was pretty hard to read this method, due to the nested `if`s