### PR TITLE
fix typings for resultRenderer

### DIFF
--- a/src/Results.tsx
+++ b/src/Results.tsx
@@ -26,7 +26,7 @@ interface Props<T> {
   // optional row override style
   rowStyle?: React.CSSProperties;
   // optional result renderering function
-  resultRenderer?: <T>(item: T) => React.ReactChild;
+  resultRenderer?: Omnibar.ResultRenderer;
 }
 
 const LIST_STYLE: React.CSSProperties = {

--- a/src/ResultsItem.tsx
+++ b/src/ResultsItem.tsx
@@ -10,13 +10,13 @@ interface Props<T> {
   // onMouseLeave item callback
   onMouseLeave?: (e: any /* Event */) => void;
   // onClick callback
-  onClickItem: (e: any /* Event */) => void;
+  onClickItem?: (e: any /* Event */) => void;
   // set to true to highlight the given item
   highlighted?: boolean;
   // optional style override
   style?: React.CSSProperties;
   // optional result renderering function
-  resultRenderer?: <T>(item: T) => React.ReactChild;
+  resultRenderer?: Omnibar.ResultRenderer;
 }
 
 interface State {
@@ -73,7 +73,7 @@ export default class ResultRenderer<T> extends React.PureComponent<
 
     const renderer = this.props.resultRenderer
       ? this.props.resultRenderer
-      : AnchorRenderer;
+      : AnchorRenderer as Omnibar.ResultRenderer;
 
     return (
       <li

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -32,7 +32,7 @@ declare namespace Omnibar {
     // options style on the root element
     rootStyle?: React.CSSProperties;
     // optional result renderering function
-    resultRenderer?: <T>(item: T) => React.ReactChild;
+    resultRenderer?: <T>({ item }: { item: T }) => React.ReactChild;
     // optional action override
     onAction?: <T>(item: T) => void;
     // optional input delay override

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,6 +8,9 @@ declare namespace Omnibar {
   type FunctionalExtension<T> = (query: string) => Results<T>;
   type Extension<T> = FunctionalExtension<T>;
 
+  // Renderers
+  type ResultRenderer = <T>({ item }: { item: T }) => JSX.Element;
+
   interface Props<T> {
     // list of extensions
     extensions: Array<Omnibar.Extension<T>>;
@@ -32,7 +35,7 @@ declare namespace Omnibar {
     // options style on the root element
     rootStyle?: React.CSSProperties;
     // optional result renderering function
-    resultRenderer?: <T>({ item }: { item: T }) => React.ReactChild;
+    resultRenderer?: ResultRenderer;
     // optional action override
     onAction?: <T>(item: T) => void;
     // optional input delay override


### PR DESCRIPTION
`resultRenderer` should be a function that accept a `props` object that contains `item`, not the `item` as the arg itself.