### PR TITLE
remove intermediate wrapper for ResultItem

### DIFF
--- a/__tests__/__snapshots__/Results.tsx.snap
+++ b/__tests__/__snapshots__/Results.tsx.snap
@@ -16,7 +16,14 @@ exports[`Results should render a <Results /> 1`] = `
     }
   }
 >
-  <li
+  <a
+    href="https://google.com"
+    item={
+      Object {
+        "title": "Google",
+        "url": "https://google.com",
+      }
+    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -29,28 +36,27 @@ exports[`Results should render a <Results /> 1`] = `
         "borderStyle": "solid",
         "borderTopWidth": 0,
         "boxSizing": "border-box",
+        "color": "#000",
+        "display": "block",
         "fontSize": 24,
         "height": 50,
         "lineHeight": "50px",
+        "paddingLeft": 15,
+        "paddingRight": 15,
+        "textDecoration": "none",
       }
     }
   >
-    <a
-      href="https://google.com"
-      style={
-        Object {
-          "color": "#000",
-          "display": "block",
-          "paddingLeft": 15,
-          "paddingRight": 15,
-          "textDecoration": "none",
-        }
+    Google
+  </a>
+  <a
+    href="https://dropbox.com"
+    item={
+      Object {
+        "title": "Dropbox",
+        "url": "https://dropbox.com",
       }
-    >
-      Google
-    </a>
-  </li>
-  <li
+    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -63,27 +69,19 @@ exports[`Results should render a <Results /> 1`] = `
         "borderStyle": "solid",
         "borderTopWidth": 0,
         "boxSizing": "border-box",
+        "color": "#000",
+        "display": "block",
         "fontSize": 24,
         "height": 50,
         "lineHeight": "50px",
+        "paddingLeft": 15,
+        "paddingRight": 15,
+        "textDecoration": "none",
       }
     }
   >
-    <a
-      href="https://dropbox.com"
-      style={
-        Object {
-          "color": "#000",
-          "display": "block",
-          "paddingLeft": 15,
-          "paddingRight": 15,
-          "textDecoration": "none",
-        }
-      }
-    >
-      Dropbox
-    </a>
-  </li>
+    Dropbox
+  </a>
 </ul>
 `;
 
@@ -103,54 +101,14 @@ exports[`Results should render a <Results /> with a custom row renderer 1`] = `
     }
   }
 >
-  <li
-    onClick={undefined}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    style={
-      Object {
-        "borderBottomWidth": 1,
-        "borderColor": "#ddd",
-        "borderLeftWidth": 1,
-        "borderRightWidth": 1,
-        "borderStyle": "solid",
-        "borderTopWidth": 0,
-        "boxSizing": "border-box",
-        "fontSize": 24,
-        "height": 50,
-        "lineHeight": "50px",
-      }
-    }
-  >
-    <div>
-      Title: 
-      Google
-    </div>
-  </li>
-  <li
-    onClick={undefined}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    style={
-      Object {
-        "borderBottomWidth": 1,
-        "borderColor": "#ddd",
-        "borderLeftWidth": 1,
-        "borderRightWidth": 1,
-        "borderStyle": "solid",
-        "borderTopWidth": 0,
-        "boxSizing": "border-box",
-        "fontSize": 24,
-        "height": 50,
-        "lineHeight": "50px",
-      }
-    }
-  >
-    <div>
-      Title: 
-      Dropbox
-    </div>
-  </li>
+  <div>
+    Title: 
+    Google
+  </div>
+  <div>
+    Title: 
+    Dropbox
+  </div>
 </ul>
 `;
 
@@ -175,7 +133,14 @@ exports[`Results should render a <Results /> with a max height 1`] = `
     }
   }
 >
-  <li
+  <a
+    href="https://google.com"
+    item={
+      Object {
+        "title": "Google",
+        "url": "https://google.com",
+      }
+    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -188,28 +153,27 @@ exports[`Results should render a <Results /> with a max height 1`] = `
         "borderStyle": "solid",
         "borderTopWidth": 0,
         "boxSizing": "border-box",
+        "color": "#000",
+        "display": "block",
         "fontSize": 24,
         "height": 50,
         "lineHeight": "50px",
+        "paddingLeft": 15,
+        "paddingRight": 15,
+        "textDecoration": "none",
       }
     }
   >
-    <a
-      href="https://google.com"
-      style={
-        Object {
-          "color": "#000",
-          "display": "block",
-          "paddingLeft": 15,
-          "paddingRight": 15,
-          "textDecoration": "none",
-        }
+    Google
+  </a>
+  <a
+    href="https://dropbox.com"
+    item={
+      Object {
+        "title": "Dropbox",
+        "url": "https://dropbox.com",
       }
-    >
-      Google
-    </a>
-  </li>
-  <li
+    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -222,27 +186,19 @@ exports[`Results should render a <Results /> with a max height 1`] = `
         "borderStyle": "solid",
         "borderTopWidth": 0,
         "boxSizing": "border-box",
+        "color": "#000",
+        "display": "block",
         "fontSize": 24,
         "height": 50,
         "lineHeight": "50px",
+        "paddingLeft": 15,
+        "paddingRight": 15,
+        "textDecoration": "none",
       }
     }
   >
-    <a
-      href="https://dropbox.com"
-      style={
-        Object {
-          "color": "#000",
-          "display": "block",
-          "paddingLeft": 15,
-          "paddingRight": 15,
-          "textDecoration": "none",
-        }
-      }
-    >
-      Dropbox
-    </a>
-  </li>
+    Dropbox
+  </a>
 </ul>
 `;
 
@@ -267,7 +223,14 @@ exports[`Results should render a <Results /> with a row height 1`] = `
     }
   }
 >
-  <li
+  <a
+    href="https://google.com"
+    item={
+      Object {
+        "title": "Google",
+        "url": "https://google.com",
+      }
+    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -280,28 +243,27 @@ exports[`Results should render a <Results /> with a row height 1`] = `
         "borderStyle": "solid",
         "borderTopWidth": 0,
         "boxSizing": "border-box",
+        "color": "#000",
+        "display": "block",
         "fontSize": 24,
         "height": 50,
         "lineHeight": "50px",
+        "paddingLeft": 15,
+        "paddingRight": 15,
+        "textDecoration": "none",
       }
     }
   >
-    <a
-      href="https://google.com"
-      style={
-        Object {
-          "color": "#000",
-          "display": "block",
-          "paddingLeft": 15,
-          "paddingRight": 15,
-          "textDecoration": "none",
-        }
+    Google
+  </a>
+  <a
+    href="https://dropbox.com"
+    item={
+      Object {
+        "title": "Dropbox",
+        "url": "https://dropbox.com",
       }
-    >
-      Google
-    </a>
-  </li>
-  <li
+    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -314,27 +276,19 @@ exports[`Results should render a <Results /> with a row height 1`] = `
         "borderStyle": "solid",
         "borderTopWidth": 0,
         "boxSizing": "border-box",
+        "color": "#000",
+        "display": "block",
         "fontSize": 24,
         "height": 50,
         "lineHeight": "50px",
+        "paddingLeft": 15,
+        "paddingRight": 15,
+        "textDecoration": "none",
       }
     }
   >
-    <a
-      href="https://dropbox.com"
-      style={
-        Object {
-          "color": "#000",
-          "display": "block",
-          "paddingLeft": 15,
-          "paddingRight": 15,
-          "textDecoration": "none",
-        }
-      }
-    >
-      Dropbox
-    </a>
-  </li>
+    Dropbox
+  </a>
 </ul>
 `;
 
@@ -354,7 +308,14 @@ exports[`Results should render a <Results /> with a selected item 1`] = `
     }
   }
 >
-  <li
+  <a
+    href="https://google.com"
+    item={
+      Object {
+        "title": "Google",
+        "url": "https://google.com",
+      }
+    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -368,28 +329,27 @@ exports[`Results should render a <Results /> with a selected item 1`] = `
         "borderStyle": "solid",
         "borderTopWidth": 0,
         "boxSizing": "border-box",
+        "color": "#000",
+        "display": "block",
         "fontSize": 24,
         "height": 50,
         "lineHeight": "50px",
+        "paddingLeft": 15,
+        "paddingRight": 15,
+        "textDecoration": "none",
       }
     }
   >
-    <a
-      href="https://google.com"
-      style={
-        Object {
-          "color": "#000",
-          "display": "block",
-          "paddingLeft": 15,
-          "paddingRight": 15,
-          "textDecoration": "none",
-        }
+    Google
+  </a>
+  <a
+    href="https://dropbox.com"
+    item={
+      Object {
+        "title": "Dropbox",
+        "url": "https://dropbox.com",
       }
-    >
-      Google
-    </a>
-  </li>
-  <li
+    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -402,26 +362,18 @@ exports[`Results should render a <Results /> with a selected item 1`] = `
         "borderStyle": "solid",
         "borderTopWidth": 0,
         "boxSizing": "border-box",
+        "color": "#000",
+        "display": "block",
         "fontSize": 24,
         "height": 50,
         "lineHeight": "50px",
+        "paddingLeft": 15,
+        "paddingRight": 15,
+        "textDecoration": "none",
       }
     }
   >
-    <a
-      href="https://dropbox.com"
-      style={
-        Object {
-          "color": "#000",
-          "display": "block",
-          "paddingLeft": 15,
-          "paddingRight": 15,
-          "textDecoration": "none",
-        }
-      }
-    >
-      Dropbox
-    </a>
-  </li>
+    Dropbox
+  </a>
 </ul>
 `;

--- a/__tests__/__snapshots__/ResultsItem.tsx.snap
+++ b/__tests__/__snapshots__/ResultsItem.tsx.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ResultsItem should render a <ResultsItem /> 1`] = `
-<li
+<a
+  href="https://google.com"
+  item={
+    Object {
+      "title": "Google",
+      "url": "https://google.com",
+    }
+  }
   onClick={undefined}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -14,31 +21,30 @@ exports[`ResultsItem should render a <ResultsItem /> 1`] = `
       "borderStyle": "solid",
       "borderTopWidth": 0,
       "boxSizing": "border-box",
+      "color": "#000",
+      "display": "block",
       "fontSize": 24,
       "height": 50,
       "lineHeight": "50px",
+      "paddingLeft": 15,
+      "paddingRight": 15,
+      "textDecoration": "none",
     }
   }
 >
-  <a
-    href="https://google.com"
-    style={
-      Object {
-        "color": "#000",
-        "display": "block",
-        "paddingLeft": 15,
-        "paddingRight": 15,
-        "textDecoration": "none",
-      }
-    }
-  >
-    Google
-  </a>
-</li>
+  Google
+</a>
 `;
 
 exports[`ResultsItem should render a highlighted <ResultsItem /> 1`] = `
-<li
+<a
+  href="https://google.com"
+  item={
+    Object {
+      "title": "Google",
+      "url": "https://google.com",
+    }
+  }
   onClick={undefined}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -52,25 +58,17 @@ exports[`ResultsItem should render a highlighted <ResultsItem /> 1`] = `
       "borderStyle": "solid",
       "borderTopWidth": 0,
       "boxSizing": "border-box",
+      "color": "#000",
+      "display": "block",
       "fontSize": 24,
       "height": 50,
       "lineHeight": "50px",
+      "paddingLeft": 15,
+      "paddingRight": 15,
+      "textDecoration": "none",
     }
   }
 >
-  <a
-    href="https://google.com"
-    style={
-      Object {
-        "color": "#000",
-        "display": "block",
-        "paddingLeft": 15,
-        "paddingRight": 15,
-        "textDecoration": "none",
-      }
-    }
-  >
-    Google
-  </a>
-</li>
+  Google
+</a>
 `;

--- a/src/ResultsItem.tsx
+++ b/src/ResultsItem.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { COLORS } from './constants';
+import { AnchorItem } from './modifiers/anchor';
 import AnchorRenderer from './modifiers/anchor/AnchorRenderer';
 
 interface Props<T> {
@@ -65,7 +66,7 @@ export default class ResultRenderer<T> extends React.PureComponent<
 
   render() {
     const item = this.props.item;
-    let style = { ...ITEM_STYLE, ...this.props.style };
+    let style: React.CSSProperties = { ...ITEM_STYLE, ...this.props.style };
 
     if (this.props.highlighted || this.state.hover) {
       style = { ...style, ...ITEM_HOVER_STYLE };
@@ -75,15 +76,12 @@ export default class ResultRenderer<T> extends React.PureComponent<
       ? this.props.children
       : (AnchorRenderer as Omnibar.ResultRenderer<T>);
 
-    return (
-      <li
-        style={style}
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}
-        onClick={this.props.onClickItem}
-      >
-        {renderer({ item })}
-      </li>
-    );
+    return renderer({
+      style,
+      item,
+      onMouseEnter: this.handleMouseEnter,
+      onMouseLeave: this.handleMouseLeave,
+      onClick: this.props.onClickItem,
+    });
   }
 }

--- a/src/modifiers/anchor/AnchorRenderer.tsx
+++ b/src/modifiers/anchor/AnchorRenderer.tsx
@@ -15,9 +15,14 @@ const ANCHOR_STYLE: React.CSSProperties = {
   paddingRight: 15,
 };
 
-export default function AnchorRenderer<T>(props: Props<T>) {
+export default function AnchorRenderer<T>(
+  props: Props<T> & React.HTMLAttributes<HTMLAnchorElement>
+) {
+  const { style, ...rest } = props;
+  const mergedStyle = { ...ANCHOR_STYLE, ...style };
+
   return (
-    <a href={props.item.url} style={ANCHOR_STYLE}>
+    <a href={props.item.url} style={mergedStyle} {...rest}>
       {props.item.title}
     </a>
   );

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,8 +8,24 @@ declare namespace Omnibar {
   type FunctionalExtension<T> = (query: string) => Results<T>;
   type Extension<T> = FunctionalExtension<T>;
 
+  type MouseEvent = (evt: any) => void;
+
   // Renderers
-  type ResultRenderer<T> = ({ item }: { item: T }) => React.ReactNode;
+  type ResultRenderer<T> = (
+    {
+      item,
+      style,
+      onMouseEnter,
+      onMouseLeave,
+      onClick,
+    }: {
+      item: T;
+      style?: React.CSSProperties;
+      onMouseEnter?: MouseEvent;
+      onMouseLeave?: MouseEvent;
+      onClick?: MouseEvent;
+    }
+  ) => JSX.Element;
 
   interface Props<T> {
     // results renderer function


### PR DESCRIPTION
This PR will get rid of the intermediate `<li />` wrapper a result item. This allow result items to inherit any attributes/props that are passed.

## Before

```
export function FooItem(props) {
    return <div {...props}>{props.item.title}</div>;
}

// produces...

<ol>
    <li><div {...props}>foo</div></li>
    <li><div {...props}>bar</div></li>
</ol>
```

## After

```
export function FooItem(props) {
    return <li {...props}>{props.item.title}</li>;
}

// produces...

<ol>
   <li {...props}>foo</li>
   <li {...props}>bar</li>
</ol>
```

Going forward, we should now be able to pass a custom style or attributes to our custom item renderers. This will pave the way for overriding `style` prop for future flag props that we can expose (eg: `isFocused`, `isHighlighted`).

```
<Omnibar>
    {({ item, isFocused, isHighlighted }) => {
        MY_CUSTOM_STYLE = {}; // style based on isFocused, isHighlighted, etc.

        return <FooItem item={item} style={MY_CUSTOM_STYLE} />;
    }
</Omnibar>
```