### PR TITLE
remove rowStyle and add tslib

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ const VoiceBar = withVoice(Omnibar);
 | `maxResults`         | `number`              |           | The maximum amount of results to display overall.                                      |
 | `maxViewableResults` | `number`              |           | The maximum amount of results to display in the viewable container (before scrolling). |
 | `rowHeight`          | `number`              |           | The height for each result row item                                                    |
-| `rowStyle`           | `object`              |           | Style object override for each result row item                                         |
 | `resultStyle`        | `object`              |           | Style object override for the result container                                         |
 | `onAction`           | `Function`            |           | Apply an action callback when an item is executed. Arguments: `item`                   |
 | `inputDelay`         | `number`              |           | Set an input delay used for querying extensions (Default: 100ms)                       |

--- a/__tests__/__snapshots__/Results.tsx.snap
+++ b/__tests__/__snapshots__/Results.tsx.snap
@@ -18,12 +18,6 @@ exports[`Results should render a <Results /> 1`] = `
 >
   <a
     href="https://google.com"
-    item={
-      Object {
-        "title": "Google",
-        "url": "https://google.com",
-      }
-    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -51,12 +45,6 @@ exports[`Results should render a <Results /> 1`] = `
   </a>
   <a
     href="https://dropbox.com"
-    item={
-      Object {
-        "title": "Dropbox",
-        "url": "https://dropbox.com",
-      }
-    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -135,12 +123,6 @@ exports[`Results should render a <Results /> with a max height 1`] = `
 >
   <a
     href="https://google.com"
-    item={
-      Object {
-        "title": "Google",
-        "url": "https://google.com",
-      }
-    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -168,12 +150,6 @@ exports[`Results should render a <Results /> with a max height 1`] = `
   </a>
   <a
     href="https://dropbox.com"
-    item={
-      Object {
-        "title": "Dropbox",
-        "url": "https://dropbox.com",
-      }
-    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -225,12 +201,6 @@ exports[`Results should render a <Results /> with a row height 1`] = `
 >
   <a
     href="https://google.com"
-    item={
-      Object {
-        "title": "Google",
-        "url": "https://google.com",
-      }
-    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -258,12 +228,6 @@ exports[`Results should render a <Results /> with a row height 1`] = `
   </a>
   <a
     href="https://dropbox.com"
-    item={
-      Object {
-        "title": "Dropbox",
-        "url": "https://dropbox.com",
-      }
-    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -310,12 +274,6 @@ exports[`Results should render a <Results /> with a selected item 1`] = `
 >
   <a
     href="https://google.com"
-    item={
-      Object {
-        "title": "Google",
-        "url": "https://google.com",
-      }
-    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -344,12 +302,6 @@ exports[`Results should render a <Results /> with a selected item 1`] = `
   </a>
   <a
     href="https://dropbox.com"
-    item={
-      Object {
-        "title": "Dropbox",
-        "url": "https://dropbox.com",
-      }
-    }
     onClick={undefined}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}

--- a/__tests__/__snapshots__/ResultsItem.tsx.snap
+++ b/__tests__/__snapshots__/ResultsItem.tsx.snap
@@ -3,12 +3,6 @@
 exports[`ResultsItem should render a <ResultsItem /> 1`] = `
 <a
   href="https://google.com"
-  item={
-    Object {
-      "title": "Google",
-      "url": "https://google.com",
-    }
-  }
   onClick={undefined}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -39,12 +33,6 @@ exports[`ResultsItem should render a <ResultsItem /> 1`] = `
 exports[`ResultsItem should render a highlighted <ResultsItem /> 1`] = `
 <a
   href="https://google.com"
-  item={
-    Object {
-      "title": "Google",
-      "url": "https://google.com",
-    }
-  }
   onClick={undefined}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6291,6 +6291,12 @@
         }
       }
     },
+    "tslib": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved":

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "rollup-plugin-typescript": "^0.8.1",
     "ts-jest": "^21.0.1",
     "ts-loader": "^2.3.7",
+    "tslib": "^1.8.1",
     "typescript": "^2.5.3"
   },
   "jest": {

--- a/src/Omnibar.tsx
+++ b/src/Omnibar.tsx
@@ -162,7 +162,6 @@ export default class Omnibar<T> extends React.PureComponent<
             rowHeight: this.props.rowHeight,
             maxHeight: maxHeight,
             style: this.props.resultStyle,
-            rowStyle: this.props.rowStyle,
             onMouseEnterItem: this.handleMouseEnterItem,
             onMouseLeave: this.handleMouseLeave,
             onClickItem: this.handleClickItem,

--- a/src/Results.tsx
+++ b/src/Results.tsx
@@ -25,8 +25,6 @@ interface Props<T> {
   rowHeight?: React.CSSLength;
   // optional override container style
   style?: React.CSSProperties;
-  // optional row override style
-  rowStyle?: React.CSSProperties;
 }
 
 const LIST_STYLE: React.CSSProperties = {
@@ -66,7 +64,6 @@ export default function Results<T>(props: Props<T>) {
           children: props.children,
           highlighted: props.selectedIndex === key,
           item,
-          style: props.rowStyle,
           onMouseEnter:
             props.onMouseEnterItem &&
             createHandler(props.onMouseEnterItem, key),

--- a/src/modifiers/anchor/AnchorRenderer.tsx
+++ b/src/modifiers/anchor/AnchorRenderer.tsx
@@ -18,12 +18,12 @@ const ANCHOR_STYLE: React.CSSProperties = {
 export default function AnchorRenderer<T>(
   props: Props<T> & React.HTMLAttributes<HTMLAnchorElement>
 ) {
-  const { style, ...rest } = props;
+  const { item, style, ...rest } = props;
   const mergedStyle = { ...ANCHOR_STYLE, ...style };
 
   return (
-    <a href={props.item.url} style={mergedStyle} {...rest}>
-      {props.item.title}
+    <a href={item.url} style={mergedStyle} {...rest}>
+      {item.title}
     </a>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "importHelpers": true,
     "jsx": "react",
     "moduleResolution": "node",
     "noImplicitAny": true,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -42,8 +42,6 @@ declare namespace Omnibar {
     placeholder?: string;
     // optional result item height
     rowHeight?: number;
-    // optional result item style override
-    rowStyle?: React.CSSProperties;
     // optional result list style override
     resultStyle?: React.CSSProperties;
     // options style on the root element

--- a/yarn.lock
+++ b/yarn.lock
@@ -3061,6 +3061,10 @@ ts-loader@^2.3.7:
     loader-utils "^1.0.2"
     semver "^5.0.1"
 
+tslib@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"


### PR DESCRIPTION
- Removes `rowStyle` as this can be passed down via the `children` render function now.
- Adds [`tslib`](https://github.com/Microsoft/tslib) and enable `importHelpers` to improve build size by avoiding duplicate helper methods such as `__assign`, `__extends`, and `__rest`
