### PR TITLE
 Fix ts interface for Omnibar.Props to include onFocus and onBlur

### DIFF
--- a/src/Omnibar.tsx
+++ b/src/Omnibar.tsx
@@ -119,10 +119,16 @@ export default class Omnibar<T> extends React.PureComponent<
   };
 
   handleBlur = () => {
+    if(this.props.onBlur) {
+      this.props.onBlur.call();
+    }
     setTimeout(() => this.setState({ displayResults: false }), BLUR_DELAY);
   };
 
   handleFocus = () => {
+    if(this.props.onFocus) {
+      this.props.onFocus.call();
+    }
     this.setState({ displayResults: true });
   };
 
@@ -145,6 +151,8 @@ export default class Omnibar<T> extends React.PureComponent<
       resultStyle,
       onQuery,
       onAction,
+      onFocus,
+      onBlur,
       ...rest
     } = this.props;
 

--- a/src/Omnibar.tsx
+++ b/src/Omnibar.tsx
@@ -100,9 +100,11 @@ export default class Omnibar<T> extends React.PureComponent<
     switch (evt.keyCode) {
       case KEYS.UP:
         this.prev();
+        evt.preventDefault();
         break;
       case KEYS.DOWN:
         this.next();
+        evt.preventDefault();
         break;
       case KEYS.ENTER:
         this.action();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -43,6 +43,10 @@ declare namespace Omnibar {
     // triggered when a query is made
     onQuery?: <T>(items: Array<T>) => void;
     // optional input placeholder text
+    onFocus?: <T>(item: T) => void;
+    // optional input placeholder text
+    onBlur?: <T>(item: T) => void;
+    // optional input placeholder text
     placeholder?: string;
     // alias of children
     render?: ResultRenderer<T>;


### PR DESCRIPTION
This is fix for this problem
TS2322: Type '{ placeholder: string; maxResults: number; inputDelay: number; extensions: ((candidateName: string) => Promise<any[]>)[]; style: CSSProperties; resultStyle: { width: any; }; children: ({ item, isSelected }: any) => Element; onFocus: () => void; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Omnibar<any>> & Readonly<Props<any>> & Readonly<{ children?: ReactNode; }>'.
  Property 'onFocus' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Omnibar<any>> & Readonly<Props<any>> & Readonly<{ children?: ReactNode; }>'.