### PR TITLE
Add showEmpty param to call extension with empty search string (#37)

### DIFF
--- a/src/Omnibar.tsx
+++ b/src/Omnibar.tsx
@@ -20,6 +20,7 @@ export default class Omnibar<T> extends React.PureComponent<
     render: null, // alias of children
     resultStyle: {},
     rootStyle: { position: 'relative' },
+    showEmpty: false,
   };
 
   state: Omnibar.State<T> = {
@@ -90,7 +91,7 @@ export default class Omnibar<T> extends React.PureComponent<
 
   handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const value = evt.target.value;
-    if (value) {
+    if (value || this.props.showEmpty) {
       this.query(value);
     } else {
       this.reset();
@@ -129,6 +130,9 @@ export default class Omnibar<T> extends React.PureComponent<
   };
 
   handleFocus = (evt: React.FocusEvent<HTMLInputElement>) => {
+    if (this.state.results.length === 0 && this.props.showEmpty) {
+      this.query("");
+    }
     if (this.props.onFocus) {
       this.props.onFocus(evt);
     }
@@ -156,6 +160,7 @@ export default class Omnibar<T> extends React.PureComponent<
       onAction,
       onFocus,
       onBlur,
+      showEmpty,
       ...rest
     } = this.props;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -56,6 +56,8 @@ declare namespace Omnibar {
     rootStyle?: React.CSSProperties;
     // optional input bar style override
     style?: React.CSSProperties;
+    // optional call extension with empty input
+    showEmpty?: boolean;
   }
 
   interface State<T> {


### PR DESCRIPTION
This params helps to show some default results when search string is empty.
I use it to show search history as default result items.